### PR TITLE
Update for v2.5.3-beta

### DIFF
--- a/FuturaeDemo/app/build.gradle
+++ b/FuturaeDemo/app/build.gradle
@@ -5,18 +5,14 @@ apply plugin: 'com.google.firebase.crashlytics'
 
 android {
     compileSdkVersion 34
+    namespace "com.futurae.futuraedemo"
 
     defaultConfig {
         applicationId "com.futurae.futuraedemo"
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 250
-        versionName "2.5.2-beta"
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        versionCode 253
+        versionName "2.5.3-beta"
     }
 
     buildTypes {
@@ -39,7 +35,19 @@ android {
         viewBinding true
     }
 
-    lintOptions {
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+            returnDefaultValues = true
+        }
+        reportDir "$rootDir/test-reports"
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    testBuildType "release"
+    lint {
         abortOnError false
     }
 
@@ -56,6 +64,13 @@ repositories {
             password = "$GITHUB_TOKEN"
         }
     }
+        maven {
+        url "https://maven.pkg.github.com/Futurae-Technologies/android-adaptive-sdk"
+        credentials {
+            username = "$GITHUB_ACTOR"
+            password = "$GITHUB_TOKEN"
+        }
+    }
     google()
     mavenCentral()
 }
@@ -64,7 +79,7 @@ dependencies {
 
     implementation "androidx.core:core-ktx:1.12.0"
     implementation "androidx.appcompat:appcompat:1.6.1"
-    implementation "androidx.activity:activity-ktx:1.8.0"
+    implementation "androidx.activity:activity-ktx:1.8.1"
     implementation "androidx.fragment:fragment-ktx:1.6.2"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"
@@ -84,9 +99,12 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging-ktx'
 
     // Futurae SDK
-    implementation 'com.futurae.sdk:futuraekit-beta:2.5.2-beta'
+    implementation 'com.futurae.sdk:futuraekit-beta:2.5.3-beta'
     // OPTIONAL - Adaptive SDK.
     implementation 'com.futurae.sdk:adaptive:1.0.2-alpha'
+
+    // UNIT TESTS
+    testImplementation "junit:junit:4.13.2"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/FuturaeDemo/app/src/test/java/com/futurae/futuraedemo/SampleTest.kt
+++ b/FuturaeDemo/app/src/test/java/com/futurae/futuraedemo/SampleTest.kt
@@ -1,0 +1,16 @@
+package com.futurae.futuraedemo
+
+import com.futurae.sdk.exception.FTSignatureException
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+
+class TestingTests {
+    @Test
+    fun `sample test`() {
+        val exception = FTSignatureException("msg", Throwable())
+        val expected = 4
+        assertEquals(expected, 2 + 2)
+        assertEquals("msg", exception.message)
+    }
+}

--- a/FuturaeDemo/build.gradle
+++ b/FuturaeDemo/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
-        classpath 'com.google.gms:google-services:4.3.14'
+        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.google.gms:google-services:4.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.firebase:firebase-crashlytics-gradle:2.9.9"
 
@@ -20,8 +20,4 @@ allprojects {
         mavenCentral()
         jcenter()
     }
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
 }

--- a/FuturaeDemo/gradle/wrapper/gradle-wrapper.properties
+++ b/FuturaeDemo/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 22 17:41:42 CEST 2020
+#Wed Dec 20 12:12:40 EET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip


### PR DESCRIPTION
### Changelog
- Fix Keystore crash for Key generation using Strongbox on Android devices 8 or lower.