### PR TITLE
Update for v2.5.4-beta

### DIFF
--- a/FuturaeDemo/app/build.gradle
+++ b/FuturaeDemo/app/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 34
         versionCode 253
-        versionName "2.5.3-beta"
+        versionName "2.5.4-beta"
     }
 
     buildTypes {
@@ -79,12 +79,12 @@ dependencies {
 
     implementation "androidx.core:core-ktx:1.12.0"
     implementation "androidx.appcompat:appcompat:1.6.1"
-    implementation "androidx.activity:activity-ktx:1.8.1"
+    implementation "androidx.activity:activity-ktx:1.8.2"
     implementation "androidx.fragment:fragment-ktx:1.6.2"
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"
-    implementation "androidx.lifecycle:lifecycle-process:2.6.2"
-    implementation "com.google.android.material:material:1.10.0"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
+    implementation "androidx.lifecycle:lifecycle-process:2.7.0"
+    implementation "com.google.android.material:material:1.11.0"
 
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
 
@@ -99,7 +99,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging-ktx'
 
     // Futurae SDK
-    implementation 'com.futurae.sdk:futuraekit-beta:2.5.3-beta'
+    implementation 'com.futurae.sdk:futuraekit-beta:2.5.4-beta'
     // OPTIONAL - Adaptive SDK.
     implementation 'com.futurae.sdk:adaptive:1.0.2-alpha'
 

--- a/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/fragment/FragmentSettings.kt
+++ b/FuturaeDemo/app/src/main/java/com/futurae/futuraedemo/ui/fragment/FragmentSettings.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import com.futurae.futuraedemo.FuturaeSdkWrapper
@@ -20,17 +21,15 @@ import com.futurae.futuraedemo.util.showDialog
 import com.futurae.futuraedemo.util.showErrorAlert
 import com.futurae.sdk.Callback
 import com.futurae.sdk.FuturaeCallback
-import com.futurae.sdk.FuturaeResultCallback
 import com.futurae.sdk.FuturaeSDK
 import com.futurae.sdk.LockConfigurationType
 import com.futurae.sdk.SDKConfiguration
-import com.futurae.sdk.model.AccountsStatus
 import com.futurae.sdk.debug.FuturaeDebugUtil
+import com.futurae.sdk.exception.FTMissingTokensException
+import com.futurae.sdk.exception.LockCorruptedStateException
 import com.futurae.sdk.model.IntegrityResult
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.lang.IllegalStateException
 
 
 class FragmentSettings : Fragment() {
@@ -144,6 +143,18 @@ class FragmentSettings : Fragment() {
         }
         binding.buttonClearV2LocalStorageKey.setOnClickListener {
             FuturaeDebugUtil.corruptEncryptedStorageKey(requireContext())
+        }
+        binding.buttonCheckSigning.setOnClickListener {
+            try {
+                FuturaeSDK.validateSDKSigning()
+                Toast.makeText(requireContext(),"SDK healthy", Toast.LENGTH_SHORT).show()
+            } catch (e : Throwable) {
+                when(e) {
+                    is IllegalStateException -> showErrorAlert("SDK Uninitialized",e)
+                    is LockCorruptedStateException -> showErrorAlert("SDK Corrupted",e)
+                    is FTMissingTokensException -> showErrorAlert("SDK Recoverable error",e)
+                }
+            }
         }
     }
 

--- a/FuturaeDemo/app/src/main/res/layout/fragment_sdk_settings.xml
+++ b/FuturaeDemo/app/src/main/res/layout/fragment_sdk_settings.xml
@@ -77,6 +77,13 @@
             android:layout_marginTop="10dp"
             android:text="Clear V2 storage key" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonCheckSigning"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:text="Check SDK signing" />
+
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/FuturaeDemo/build.gradle
+++ b/FuturaeDemo/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.2.1'
         classpath 'com.google.gms:google-services:4.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.firebase:firebase-crashlytics-gradle:2.9.9"

--- a/FuturaeDemo/gradle.properties
+++ b/FuturaeDemo/gradle.properties
@@ -3,3 +3,5 @@ android.enableJetifier=true
 
 org.gradle.jvmargs=-Xmx4608m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+
+android.enableR8.fullMode=false


### PR DESCRIPTION
### Changelog
- `FuturaeSDK.validateSDKSigning` to allow verifying the validity of SDK cryptographic material
- Updated SDK's http client configuration to prevent a specific network timeout error from taking more than 60 seconds.