### PR TITLE
[Release] Update for release v3.8.0-beta

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.1.2"
-kotlin = "1.9.25"
+agp = "8.10.0"
+kotlin = "2.2.0"
 crashlytics = "3.0.3"
 google-services = "4.4.2"
 
@@ -10,6 +10,7 @@ google-services = "4.4.2"
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics"}


### PR DESCRIPTION
### Changelog

#### New Features
- **Application Integrity Check Embedded into Enrollment and Authentication flow:** Expose new feature which automatically transmits integrity verdict information, based on the <a href="https://developer.android.com/google/play/integrity">Google Play Integrity API</a>, to the backend during enrollment and authentication. To it setup:
- provide your Cloud Project Number on `futurae.xml`, using key `ftr_cloud_project_number`.
- configure the IV timeout through SDK Configuration during SDK launch by calling `SDKConfiguration.Builder.setBlockingIVCollectionTimeoutOnAuthMillis()` method.
Please note that this feature needs to be enabled for the respective Futurae Service(s) which this SDK is associated with and the Futurae SDK instance. For further details contact the Futurae support at support@futurae.